### PR TITLE
Added checkout step

### DIFF
--- a/.github/workflows/publish-dispatch.yml
+++ b/.github/workflows/publish-dispatch.yml
@@ -22,6 +22,12 @@ jobs:
           private-key: ${{ secrets.BJ_PROTOCOLS_APP_PK }}
           owner: blockjoy
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: blockjoy/blockvisor
+
       - name: Get Tag Name
         id: get-tag
         run: echo "TAG_NAME=$(git describe --tags)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I've added the check out step back, without it, we're not able to retrieve the tags so we don't know what tag_version to dispatch and publish.